### PR TITLE
Add a "Who Built This" view #21

### DIFF
--- a/app/assets/stylesheets/screen.css
+++ b/app/assets/stylesheets/screen.css
@@ -138,6 +138,11 @@ a.btn {
   margin: 5px 0;
 }
 
+.sidebar #built-by{
+  margin-top: 10%;
+  vertical-align: bottom;
+}
+
 .sidebar #feedback {
   margin-top: 5px;
 }

--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -27,6 +27,8 @@
         %p
           %a{:href => URI.escape("mailto:info@brewingabetterforest.com?subject=#{t("titles.main", :thing => t("defaults.thing").titleize)} - #{t("links.feedback").titleize}")}
             = t("links.feedback")
+      #built-by
+        = link_to "Who built this?", "https://github.com/ballPointPenguin/adopt-a-tree/graphs/contributors"
     .table-cell.map-container
       #map
         &nbsp;


### PR DESCRIPTION
Just linking to project contributors page in GitHub.  May want to frame that content and hard code additional values if we want to include folks who work on the project but have not committed code (e.g. Valerie).

Or we can `curl` to get contributor names (see issue comments for details) but that will take some cycles.